### PR TITLE
Display of debug mode activation message

### DIFF
--- a/app/src/main/java/com/snaggly/ksw_toolkit/gui/ToolKit.kt
+++ b/app/src/main/java/com/snaggly/ksw_toolkit/gui/ToolKit.kt
@@ -45,6 +45,7 @@ class ToolKit(private val coreServiceClient: CoreServiceClient) : Fragment() {
     private lateinit var startAtBootSwitch: SwitchCompat
     private lateinit var startAtBootSwitchText: TextView
     private lateinit var newerVersionTextView : TextView
+    private lateinit var enableUsbDebuggingTextView : TextView
 
     private var latestGitHubRelease : GitHubRelease? = null
 
@@ -147,6 +148,9 @@ class ToolKit(private val coreServiceClient: CoreServiceClient) : Fragment() {
                 versionTextView.text = packageInfo.versionName
                 isInInstallMode = false
             }
+            enableUsbDebuggingTextView.visibility = View.GONE
+            if (mViewModel.isAdbDebuggingDisabled(requireContext()))
+                enableUsbDebuggingTextView.visibility = View.VISIBLE
         }
     }
 
@@ -192,6 +196,7 @@ class ToolKit(private val coreServiceClient: CoreServiceClient) : Fragment() {
         startAtBootSwitch = requireView().findViewById(R.id.startAppAtBootTgl)
         startAtBootSwitchText = requireView().findViewById(R.id.start_at_boot_txt)
         newerVersionTextView = requireView().findViewById(R.id.newerVersionTextView)
+        enableUsbDebuggingTextView = requireView().findViewById(R.id.enableUsbDebuggingTextView)
 
         startStopServiceBtn.requestFocus()
     }

--- a/app/src/main/java/com/snaggly/ksw_toolkit/gui/viewmodels/ToolKitViewModel.kt
+++ b/app/src/main/java/com/snaggly/ksw_toolkit/gui/viewmodels/ToolKitViewModel.kt
@@ -3,6 +3,7 @@ package com.snaggly.ksw_toolkit.gui.viewmodels
 import android.app.Application
 import android.content.Context
 import android.provider.Settings
+import android.provider.Settings.Global.*
 import android.widget.Toast
 import androidx.lifecycle.AndroidViewModel
 import com.snaggly.ksw_toolkit.R
@@ -84,5 +85,10 @@ class ToolKitViewModel(application: Application) : AndroidViewModel(application)
          }catch (exception : Exception) {
              Toast.makeText(context, context.resources.getText(R.string.could_not_check_service), Toast.LENGTH_LONG).show()
          }
+    }
+
+    fun isAdbDebuggingDisabled(context: Context) : Boolean {
+        return ((getInt(context.contentResolver, ADB_ENABLED,0) == 0)
+                && (getInt(context.contentResolver, "adb_wifi_enabled", 0) == 0))
     }
 }

--- a/app/src/main/res/layout/toolkit_fragment.xml
+++ b/app/src/main/res/layout/toolkit_fragment.xml
@@ -15,14 +15,29 @@
             android:orientation="vertical"
             android:gravity="center_vertical"
             tools:ignore="UselessParent">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="22sp"
-                android:paddingStart="20dp"
-                android:paddingEnd="20dp"
-                android:paddingTop="20dp"
-                android:text="@string/service_status"/>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="20dp"
+                    android:paddingTop="20dp"
+                    android:paddingEnd="20dp"
+                    android:text="@string/service_status"
+                    android:textSize="22sp" />
+                <TextView
+                    android:id="@+id/enableUsbDebuggingTextView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="20dp"
+                    android:paddingEnd="20dp"
+                    android:text="@string/enable_usb_debugging"
+                    android:textColor="#FF4411"
+                    android:textSize="22sp"
+                    android:textStyle="italic" />
+            </LinearLayout>
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,4 +115,5 @@
     <string name="unable_to_open_dvd_screen">Unable to open DVD Screen!</string>
     <string name="unable_to_open_dtv_screen">Unable to open DTV Screen!</string>
     <string name="unable_to_close_screen">Unable to close screen!</string>
+    <string name="enable_usb_debugging">Enable USB debugging in Android developer options</string>
 </resources>


### PR DESCRIPTION
When USB/WiFi debugging is disabled, toast windows such as "Cannot not check Services" appear and the service cannot be started.
Therefore, a message is displayed to the client only at that time.