### PR TITLE
Adjustment of UI

### DIFF
--- a/app/src/main/java/com/snaggly/ksw_toolkit/core/service/helper/CoreServiceClient.kt
+++ b/app/src/main/java/com/snaggly/ksw_toolkit/core/service/helper/CoreServiceClient.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.os.Looper
 import androidx.lifecycle.Observer
 import com.snaggly.ksw_toolkit.IKSWToolKitService
 import projekt.auto.mcu.encryption.Base64
@@ -29,8 +30,9 @@ class CoreServiceClient {
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
-            Thread.sleep(200)    // Prevent crashes during service outages
-            coreService = null
+            android.os.Handler(Looper.getMainLooper()).postDelayed({
+                coreService = null
+            },200)
         }
     }
 

--- a/app/src/main/java/com/snaggly/ksw_toolkit/gui/EventManager.kt
+++ b/app/src/main/java/com/snaggly/ksw_toolkit/gui/EventManager.kt
@@ -1,5 +1,6 @@
 package com.snaggly.ksw_toolkit.gui
 
+import android.app.AlertDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -97,8 +98,15 @@ class EventManager(private val coreServiceClient: CoreServiceClient) : Fragment(
 
     private fun initBtnClick() {
         resetDefaultBtn.setOnClickListener {
-            coreServiceClient.coreService?.setDefaultBtnLayout()
-            initBtnClick()
+            AlertDialog.Builder(activity, R.style.alertDialogNight)
+                .setTitle(R.string.reset_defaults)
+                .setMessage(R.string.reset_default_dialog_message)
+                .setPositiveButton("OK", { dialog, which ->
+                    coreServiceClient.coreService?.setDefaultBtnLayout()
+                    initBtnClick()
+                })
+                .setNegativeButton("CANCEL", null)
+                .show()
         }
         setOnClickEvent(telephoneBtn, EventManagerTypes.TelephoneButton)
         setOnClickEvent(telephonePickUpBtn, EventManagerTypes.TelephoneButtonPickUp)

--- a/app/src/main/java/com/snaggly/ksw_toolkit/gui/EventManagerSelectAction.kt
+++ b/app/src/main/java/com/snaggly/ksw_toolkit/gui/EventManagerSelectAction.kt
@@ -1,6 +1,7 @@
 package com.snaggly.ksw_toolkit.gui
 
 import android.os.Bundle
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -108,24 +109,28 @@ class EventManagerSelectAction(private val coreServiceClient: CoreServiceClient,
                 when (mode) {
                     ActionMode.InvokeKeyEvent -> {
                         invokeKeyButton.isChecked = false
+                        invokeKeyButton.jumpDrawablesToCurrentState()
                         listKeyEvents.clearAnimation()
                         listKeyEvents.startAnimation(leaveToTopAnimation)
                         listKeyEvents.visibility = View.GONE
                     }
                     ActionMode.StartApp -> {
                         startAppButton.isChecked = false
+                        startAppButton.jumpDrawablesToCurrentState()
                         listApps.clearAnimation()
                         listApps.startAnimation((leaveToTopAnimation))
                         listApps.visibility = View.GONE
                     }
                     ActionMode.SendMcuCommand -> {
                         mcuCommandsButton.isChecked = false
+                        mcuCommandsButton.jumpDrawablesToCurrentState()
                         listMcuCommands.clearAnimation()
                         listMcuCommands.startAnimation((leaveToTopAnimation))
                         listMcuCommands.visibility = View.GONE
                     }
                     ActionMode.StartTaskerTask -> {
                         taskerTaskButton.isChecked = false
+                        taskerTaskButton.jumpDrawablesToCurrentState()
                         listTaskerTasks.clearAnimation()
                         listTaskerTasks.startAnimation((leaveToTopAnimation))
                         listTaskerTasks.visibility = View.GONE
@@ -134,7 +139,9 @@ class EventManagerSelectAction(private val coreServiceClient: CoreServiceClient,
                 }
                 mode = ActionMode.DoNothing
                 mViewModel.resetEvent()
-                actionEvent.notifyView()
+                android.os.Handler(Looper.getMainLooper()).postDelayed({
+                    actionEvent.notifyView()
+                },250)
             }
         }
         invokeKeyButton.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
@@ -283,8 +290,13 @@ class EventManagerSelectAction(private val coreServiceClient: CoreServiceClient,
                         getText(R.string.tasker_not_enabled).toString().showMessage()
                     AccessBlocked ->
                         getText(R.string.tasker_access_blocked).toString().showMessage()
+
+                    // If I install Tasker after KSW-ToolKit, I get this status because I don't have permission
+                    // But actually the task seems to work, so it is commented out
+                    /*
                     NoPermission ->
                         getText(R.string.tasker_no_permission).toString().showMessage()
+                    */
                 }
             }
         }

--- a/app/src/main/java/com/snaggly/ksw_toolkit/gui/SystemTwaks.kt
+++ b/app/src/main/java/com/snaggly/ksw_toolkit/gui/SystemTwaks.kt
@@ -74,6 +74,7 @@ class SystemTwaks(val coreServiceClient: CoreServiceClient) : Fragment() {
         sharedPref = requireContext().getSharedPreferences(SystemTwaks::javaClass.name, Context.MODE_PRIVATE)
         viewModel.resetConfig()
         setSettings()
+        nightBrightnessSeekBar.isEnabled = nightBrightnessToggle.isChecked
     }
 
     private fun initElements() {

--- a/app/src/main/java/com/snaggly/ksw_toolkit/util/adapters/ListTypeAdapter.kt
+++ b/app/src/main/java/com/snaggly/ksw_toolkit/util/adapters/ListTypeAdapter.kt
@@ -1,6 +1,7 @@
 package com.snaggly.ksw_toolkit.util.adapters
 
 import android.content.res.ColorStateList
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -24,6 +25,7 @@ class ListTypeAdapter(private val appsList: ArrayList<out ListType>,
 
     inner class AppsListViewHolder(itemView: View, private val onClickListener: OnAppClickListener)
         : RecyclerView.ViewHolder(itemView), View.OnClickListener, View.OnFocusChangeListener {
+        val appLayoutView : View? = itemView.findViewById(R.id.apps_list_layout)
         val appIconView : ImageView = itemView.findViewById(R.id.apps_list_icon)
         val appNameView : TextView = itemView.findViewById(R.id.apps_list_text)
         val appRadioButtonView : RadioButton = itemView.findViewById(R.id.apps_list_radioBtn)
@@ -35,10 +37,14 @@ class ListTypeAdapter(private val appsList: ArrayList<out ListType>,
 
         override fun onClick(v: View?) {
             previousSelection?.appRadioButtonView?.isChecked = false
+            previousSelection?.appRadioButtonView?.jumpDrawablesToCurrentState()
             appRadioButtonView.isChecked = true
             previousSelection = this
             selectedApp = bindingAdapterPosition
-            onClickListener.onAppClick(bindingAdapterPosition)
+            appLayoutView?.setBackgroundResource(R.drawable.ksw_id7_itme_select_bg_focused)
+            android.os.Handler(Looper.getMainLooper()).postDelayed({
+                onClickListener.onAppClick(bindingAdapterPosition)
+            },250)
         }
 
         override fun onFocusChange(v: View?, hasFocus: Boolean) {

--- a/app/src/main/res/drawable/btn_selector.xml
+++ b/app/src/main/res/drawable/btn_selector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true" android:drawable="@drawable/ksw_id7_itme_select_bg_pressed" />
+    <item android:state_pressed="true" android:drawable="@drawable/ksw_id7_btn_pressed" />
     <item android:state_focused="true" android:drawable="@drawable/ksw_id7_itme_select_bg_focused" />
     <item android:state_enabled="false" android:drawable="@drawable/ksw_id7_itme_select_bg_normal" />
     <item android:drawable="@drawable/ksw_id7_itme_select_bg_normal" />

--- a/app/src/main/res/layout/apps_view_list.xml
+++ b/app/src/main/res/layout/apps_view_list.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
     android:focusable="true"
+    android:id="@+id/apps_list_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@drawable/btn_selector"
-    android:backgroundTint="@color/cardview_dark_background"
+    android:backgroundTint="@color/grey_600"
     xmlns:tools="http://schemas.android.com/tools">
 
     <ImageView
@@ -34,6 +35,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="10dp"
+        android:clickable="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,4 +9,6 @@
     <color name="white">#FFFFFFFF</color>
     <color name="grey">#B8B8B8</color>
     <color name="transparent">#00000000</color>
+    <color name="grey_600">#FF757575</color>
+    <color name="grey_700">#FF616161</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,8 +117,9 @@
     <string name="unable_to_close_screen">Unable to close screen!</string>
     <string name="enable_usb_debugging">Enable USB debugging in Android developer options</string>
     <string name="start_tasker_task">Start Tasker Task</string>
-    <string name="tasker_not_installed">Tasker app not installed</string>
+    <string name="tasker_not_installed">Tasker app not found. To install, reinstall KSW-ToolKit</string>
     <string name="tasker_not_enabled">Tasker disabled by the user</string>
     <string name="tasker_access_blocked">Tasker external access disabled</string>
     <string name="tasker_no_permission">Tasker no permitted</string>
+    <string name="reset_default_dialog_message">All ECU EVENT settings are reset to defaults</string>
 </resources>


### PR DESCRIPTION
Changed standby method for service outages

Change the image when the button is tapped

NightBrightness seek bar status is reflected when System Tweaks is opened

Show dialog before initializing Mcu Event Manager

Corrected the status of radio buttons in Mcu Event Manager

Modified the function list and the DoNothing button in Mcu Event Manager to be easily recognized by changing the weight and background when they are selected

Tasker's NoPermission status did no real harm, so the message stopped being displayed.

